### PR TITLE
chore(RHTAPWATCH-1285): remove the input of status-path

### DIFF
--- a/tests/test_rpm_verifier.py
+++ b/tests/test_rpm_verifier.py
@@ -356,11 +356,6 @@ class TestMain:
 
         return _mock_generate_output
 
-    @pytest.fixture()
-    def status_path(self, tmp_path: Path) -> Path:
-        """Status temp file"""
-        return tmp_path / "status"
-
     @pytest.mark.parametrize(
         ("fail_unsigned", "has_errors"),
         [
@@ -383,9 +378,10 @@ class TestMain:
         mock_image_processor: MagicMock,
         fail_unsigned: bool,
         has_errors: bool,
-        status_path: Path,
+        tmp_path: Path,
     ) -> None:
         """Test call to rpm_verifier.py main function"""
+        status_path = tmp_path / "status"
         generate_output_mock = create_generate_output_mock(with_failures=has_errors)
         rpm_verifier.main(  # pylint: disable=no-value-for-parameter
             args=[
@@ -394,9 +390,7 @@ class TestMain:
                 "--fail-unsigned",
                 fail_unsigned,
                 "--workdir",
-                "some/path",
-                "--status-path",
-                str(status_path),
+                tmp_path,
             ],
             obj={},
             standalone_mode=False,
@@ -415,11 +409,12 @@ class TestMain:
         self,
         create_generate_output_mock: MagicMock,
         mock_image_processor: MagicMock,  # pylint: disable=unused-argument
-        status_path: Path,
+        tmp_path: Path,
     ) -> None:
         """Test call to rpm_verifier.py main function fails
         when whe 'fail-unsigned' flag is used and there are unsigned RPMs
         """
+        status_path = tmp_path / "status"
         fail_unsigned: bool = True
         generate_output_mock = create_generate_output_mock(with_failures=True)
         with pytest.raises(SystemExit) as err:
@@ -430,9 +425,7 @@ class TestMain:
                     "--fail-unsigned",
                     fail_unsigned,
                     "--workdir",
-                    "some/path",
-                    "--status-path",
-                    str(status_path),
+                    tmp_path,
                 ],
                 obj={},
                 standalone_mode=False,

--- a/verify_rpms/rpm_verifier.py
+++ b/verify_rpms/rpm_verifier.py
@@ -163,20 +163,13 @@ class ImageProcessor:
     type=click.Path(path_type=Path),
     required=True,
 )
-@click.option(
-    "--status-path",
-    help="Path in which the status will be written to",
-    type=click.Path(path_type=Path),
-    required=True,
-)
 def main(
     img_input: str,
     fail_unsigned: bool,
     workdir: Path,
-    status_path: Path,
 ) -> None:
     """Verify RPMs are signed"""
-
+    status_path: Path = workdir / "status"
     processor = ImageProcessor(workdir=workdir)
     processed_image = processor(img=img_input)
 


### PR DESCRIPTION
`status-path` is not been used anywhere in the task itself, We are using <workdir>/status

Because we are removing it, we need to add the comment `# pylint: disable=unspecified-encoding` for pylint