### PR TITLE
chore(KFLUXVNGD-283): install jq

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ ADD . /tmp/src
 ADD --chown=root:root --chmod=644 data/ca-trust/* /etc/pki/ca-trust/source/anchors
 RUN /usr/bin/fix-permissions /tmp/src \
     && /usr/bin/update-ca-trust
-RUN yum install -y krb5-workstation skopeo
+RUN yum install -y krb5-workstation skopeo jq
 RUN curl -L https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash
 RUN wget https://github.com/mikefarah/yq/releases/download/v4.45.1/yq_linux_amd64.tar.gz -O - |\
     tar xz && mv yq_linux_amd64 /usr/bin/yq


### PR DESCRIPTION
It is needed to help helm select the right auth from a dockerconfig json containing multiple auths.