### PR TITLE
Establish a renovate schedule

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,6 @@
+{
+  "updateNotScheduled": false,
+  "schedule": [
+    "after 5pm on sunday"
+  ]
+}


### PR DESCRIPTION
This should slow down the influx of dependency updates and batch them, which will in turn slow down the influx of changes to the build-definitions repo. Throttling our rebuilds.