### PR TITLE
feat: add python-based implementation for buildind helm charts

### DIFF
--- a/.github/scripts/helm-chart-oci-ci-runner-e2e.sh
+++ b/.github/scripts/helm-chart-oci-ci-runner-e2e.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+# GitHub Actions CI runner: start Zot (TLS), build the tools image, run the in-image e2e script.
+# Expects: GITHUB_WORKSPACE, GITHUB_RUN_ID, RUNNER_TEMP, ZOT_IMAGE, GITHUB_SHA.
+# The in-container script runs helm_chart_oci twice: explicit CHART_VERSION and git describe.
+set -euo pipefail
+
+: "${GITHUB_WORKSPACE:?}"
+: "${GITHUB_RUN_ID:?}"
+: "${RUNNER_TEMP:?}"
+: "${ZOT_IMAGE:?}"
+: "${GITHUB_SHA:?}"
+
+cd "${GITHUB_WORKSPACE}"
+
+# Tag HEAD so helm_chart_oci can resolve the chart version via git describe (TAG_PREFIX=helm-).
+git config user.email "helm-chart-oci-e2e@localhost"
+git config user.name "helm-chart-oci-e2e"
+git tag -f "helm-1.2.3" HEAD
+
+NET="helm-oci-e2e-${GITHUB_RUN_ID}"
+REG_CONTAINER="helm-reg-${GITHUB_RUN_ID}"
+ZOT_DIR="${RUNNER_TEMP}/zot-e2e-${GITHUB_RUN_ID}"
+mkdir -p "${ZOT_DIR}/data" "${ZOT_DIR}/registry-ca" "${ZOT_DIR}/registry-trust"
+
+# Local CA + server cert so clients verify TLS with HELM_CHART_OCI_REGISTRY_CERT_DIR (no insecure skip).
+openssl genrsa -out "${ZOT_DIR}/registry-ca/ca.key" 2048
+openssl req -new -x509 -key "${ZOT_DIR}/registry-ca/ca.key" -sha256 -days 1 \
+  -out "${ZOT_DIR}/registry-ca/ca.crt" \
+  -subj "/CN=helm-chart-oci-e2e-registry-ca"
+
+openssl genrsa -out "${ZOT_DIR}/domain.key" 2048
+openssl req -new -key "${ZOT_DIR}/domain.key" -out "${ZOT_DIR}/domain.csr" \
+  -subj "/CN=${REG_CONTAINER}" \
+  -addext "subjectAltName=DNS:${REG_CONTAINER}"
+openssl x509 -req -in "${ZOT_DIR}/domain.csr" \
+  -CA "${ZOT_DIR}/registry-ca/ca.crt" -CAkey "${ZOT_DIR}/registry-ca/ca.key" \
+  -CAcreateserial -out "${ZOT_DIR}/domain.crt" -days 1 -copy_extensions copyall
+rm -f "${ZOT_DIR}/domain.csr"
+
+# Skopeo --*-cert-dir must not see private keys (e.g. ca.key): it treats *key as
+# client TLS material and errors "missing client certificate ca.cert for key ca.key".
+cp "${ZOT_DIR}/registry-ca/ca.crt" "${ZOT_DIR}/registry-trust/ca.crt"
+
+jq -n \
+  --arg cert /srv/zot/domain.crt \
+  --arg key /srv/zot/domain.key \
+  '{
+    distSpecVersion: "1.1.1",
+    storage: {rootDirectory: "/srv/zot/data"},
+    http: {
+      address: "0.0.0.0",
+      port: "5000",
+      tls: {cert: $cert, key: $key},
+      accessControl: {
+        repositories: {
+          "**": {
+            anonymousPolicy: ["read", "create", "update"]
+          }
+        }
+      }
+    },
+    log: {level: "error"}
+  }' >"${ZOT_DIR}/config.json"
+
+sudo chown -R 1001:1001 "${ZOT_DIR}"
+
+docker network create "$NET"
+docker run -d --name "$REG_CONTAINER" --network "$NET" \
+  -v "${ZOT_DIR}:/srv/zot:z" \
+  "${ZOT_IMAGE}"
+sleep 5
+if [ "$(docker inspect -f '{{.State.Running}}' "${REG_CONTAINER}")" != "true" ]; then
+  echo "Zot did not stay running; logs:"
+  docker logs "${REG_CONTAINER}" 2>&1 || true
+  exit 1
+fi
+
+docker build -t konflux-tools-e2e:ci .
+
+REPO_NO_TAG="${REG_CONTAINER}:5000/helm-oci/tools"
+
+docker run --rm \
+  --user "$(id -u):$(id -g)" \
+  --network "$NET" \
+  -e HELM_CHART_OCI_REGISTRY_CERT_DIR=/tmp/zot-registry-ca \
+  -e HOME=/tmp/e2e-home \
+  -e "E2E_CHART_REPO_NO_TAG=${REPO_NO_TAG}" \
+  -e "GITHUB_RUN_ID=${GITHUB_RUN_ID}" \
+  -e "COMMIT_SHA=${GITHUB_SHA}" \
+  -e SOURCE_CODE_DIR=source \
+  -e CHART_CONTEXT=chart \
+  -e VERSION_SUFFIX= \
+  -e TAG_PREFIX=helm- \
+  -e IMAGE_MAPPINGS='[]' \
+  -e APP_VERSION=e2e \
+  -v "${ZOT_DIR}/registry-trust:/tmp/zot-registry-ca:ro" \
+  -v "${GITHUB_WORKSPACE}:/work" \
+  -w /work \
+  konflux-tools-e2e:ci \
+  bash /work/.github/scripts/helm-chart-oci-tools-image-e2e.sh

--- a/.github/scripts/helm-chart-oci-tools-image-e2e.sh
+++ b/.github/scripts/helm-chart-oci-tools-image-e2e.sh
@@ -1,0 +1,144 @@
+#!/usr/bin/env bash
+# Run inside the konflux tools container (mirrors Tekton helm-chart-oci-e2e task layout).
+#
+# Runs helm_chart_oci twice: (1) explicit CHART_VERSION, (2) version from git (helm-* tag).
+#
+# Registry TLS: when HELM_CHART_OCI_REGISTRY_CERT_DIR contains ca.crt (PEM), helm_chart_oci
+# and helm pull verify the registry using that CA (TLS verification on).
+# Alternatively: HELM_CHART_OCI_TLS_VERIFY=false or HELM_CHART_OCI_PLAIN_HTTP=1 for insecure paths.
+set -euo pipefail
+
+: "${E2E_CHART_REPO_NO_TAG:?set to registry chart repo without tag (e.g. host:5000/helm-oci/tools)}"
+: "${GITHUB_RUN_ID:?}"
+: "${COMMIT_SHA:?}"
+
+WORKSPACE="${WORKSPACE:-/work}"
+E2E_EXPLICIT_VERSION="${E2E_EXPLICIT_VERSION:-9.8.7}"
+
+git config --global --add safe.directory "${WORKSPACE}" 2>/dev/null || true
+
+mkdir -p "${HOME}/.docker"
+auth="$(printf '%s' 'x:x' | base64 -w0)"
+jq -n --arg repo "${E2E_CHART_REPO_NO_TAG}" --arg auth "${auth}" \
+  '{auths: {($repo): {auth: $auth}}}' >"${HOME}/.docker/config.json"
+
+write_minimal_chart() {
+  local root=$1
+  mkdir -p "${root}/source/chart/templates"
+  cat >"${root}/source/chart/Chart.yaml" <<'EOF'
+apiVersion: v2
+name: placeholder
+version: 0.1.0
+EOF
+  cat >"${root}/source/chart/values.yaml" <<'EOF'
+image: quay.io/example/app:latest
+EOF
+  cat >"${root}/source/chart/templates/configmap.yaml" <<'EOF'
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: e2e
+data:
+  key: value
+EOF
+}
+
+helm_pull_extra=()
+ph="${HELM_CHART_OCI_PLAIN_HTTP:-}"
+tv="${HELM_CHART_OCI_TLS_VERIFY:-true}"
+cert_dir="${HELM_CHART_OCI_REGISTRY_CERT_DIR:-}"
+tls_relaxed=0
+if [[ "${tv,,}" =~ ^(0|false|no|off)$ ]]; then
+  tls_relaxed=1
+fi
+if [[ "${ph,,}" =~ ^(1|true|yes)$ ]]; then
+  helm_pull_extra+=(--plain-http)
+elif [[ -n "${cert_dir}" && -f "${cert_dir}/ca.crt" && "${tls_relaxed}" -eq 0 ]]; then
+  helm_pull_extra+=(--ca-file "${cert_dir}/ca.crt")
+elif [[ "${tls_relaxed}" -eq 1 ]]; then
+  helm_pull_extra+=(--insecure-skip-tls-verify)
+fi
+
+run_phase() {
+  local phase=$1 image=$2
+  local explicit_version=${3:-}
+  local work="${WORKSPACE}/e2e-${phase}"
+  local url_result="/tmp/pushed-image-url-${phase}"
+  local digest_result="/tmp/pushed-image-digest-${phase}"
+
+  rm -rf "${work}"
+  mkdir -p "${work}"
+  write_minimal_chart "${work}"
+
+  (
+    cd "${work}"
+    export IMAGE="${image}"
+    if [[ -n "${explicit_version}" ]]; then
+      export CHART_VERSION="${explicit_version}"
+    else
+      unset CHART_VERSION
+    fi
+    helm_chart_oci \
+      --workdir "${work}" \
+      --result-image-url "${url_result}" \
+      --result-image-digest "${digest_result}" \
+      values.yaml
+  )
+
+  local repo="${image%:*}"
+  local chart_name="${repo##*/}"
+  local actual_url
+  actual_url="$(cat "${url_result}")"
+  local docker_tag="${actual_url##*:}"
+  local repo_from_url="${actual_url%:"${docker_tag}"}"
+  if [[ "${repo_from_url}" != "${repo}" ]]; then
+    echo "[${phase}] Unexpected repository in pushed URL"
+    echo "Expected repo: ${repo}"
+    echo "Actual URL:    ${actual_url}"
+    exit 1
+  fi
+
+  local chart_pull_version
+  if [[ -n "${explicit_version}" ]]; then
+    local expected_docker_tag="${explicit_version//+/_}"
+    if [[ "${docker_tag}" != "${expected_docker_tag}" ]]; then
+      echo "[${phase}] Unexpected chart version tag in pushed URL (OCI uses _ for + in semver)"
+      echo "Expected tag: ${expected_docker_tag}"
+      echo "Actual URL:   ${actual_url}"
+      exit 1
+    fi
+    chart_pull_version="${explicit_version}"
+  else
+    chart_pull_version="${docker_tag//_/+}"
+  fi
+
+  if [[ ! -s "${digest_result}" ]]; then
+    echo "[${phase}] Expected a non-empty pushed image digest"
+    exit 1
+  fi
+
+  local pull_dest="${work}/pulled"
+  mkdir -p "${pull_dest}"
+
+  helm pull "oci://${repo%/*}/${chart_name}" \
+    --version "${chart_pull_version}" \
+    --destination "${pull_dest}" \
+    "${helm_pull_extra[@]}"
+
+  local pulled_chart="${pull_dest}/${chart_name}-${chart_pull_version}.tgz"
+  if [[ ! -f "${pulled_chart}" ]]; then
+    echo "[${phase}] Expected pulled chart archive: ${pulled_chart}"
+    exit 1
+  fi
+
+  tar -tzf "${pulled_chart}" >/dev/null
+  echo "[${phase}] helm_chart_oci + helm pull OK"
+}
+
+IMAGE_EXPLICIT="${E2E_CHART_REPO_NO_TAG}:gha-${GITHUB_RUN_ID}-explicit"
+IMAGE_GIT="${E2E_CHART_REPO_NO_TAG}:gha-${GITHUB_RUN_ID}-git"
+
+run_phase explicit "${IMAGE_EXPLICIT}" "${E2E_EXPLICIT_VERSION}"
+run_phase git "${IMAGE_GIT}" ""
+
+echo "Helm chart OCI tools-image e2e passed (explicit CHART_VERSION + git describe)."

--- a/.github/workflows/helm-chart-oci-docker-e2e.yml
+++ b/.github/workflows/helm-chart-oci-docker-e2e.yml
@@ -1,0 +1,31 @@
+name: Helm chart OCI Docker e2e
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+  merge_group:
+    types: [checks_requested]
+
+# ZOT_IMAGE digest is updated by Renovate (customManagers regex in renovate.json).
+env:
+  ZOT_IMAGE: quay.io/konflux-ci/zot:latest@sha256:e340476adf7c644165ff49e5cc81c849bdad85e33c205429ad417e28cde59e57
+
+jobs:
+  helm-chart-oci-docker-e2e:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Build tools image and run helm_chart_oci e2e
+        run: bash "${GITHUB_WORKSPACE}/.github/scripts/helm-chart-oci-ci-runner-e2e.sh"
+
+      - name: Remove ephemeral Zot data, container, and network
+        if: always()
+        env:
+          ZOT_DIR: ${{ runner.temp }}/zot-e2e-${{ github.run_id }}
+        run: |
+          docker rm -f "helm-reg-${{ github.run_id }}" 2>/dev/null || true
+          docker network rm "helm-oci-e2e-${{ github.run_id }}" 2>/dev/null || true
+          sudo rm -rf "${ZOT_DIR}" 2>/dev/null || true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,7 +29,7 @@ jobs:
         run: pipenv sync
       - name: Run tests
         run: |
-          pipenv run pytest --cov=verify_rpms --cov-report=xml:coverage.xml tests
+          pipenv run pytest --cov=verify_rpms --cov=helm_chart_oci --cov-report=xml:coverage.xml tests
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v6
         with:

--- a/.tekton/tasks/helm-chart-oci-e2e.yaml
+++ b/.tekton/tasks/helm-chart-oci-e2e.yaml
@@ -1,0 +1,113 @@
+apiVersion: tekton.dev/v1
+kind: Task
+metadata:
+  name: helm-chart-oci-e2e
+spec:
+  description: >-
+    End-to-end validation for helm_chart_oci using the freshly built tools image.
+    Creates a minimal chart, pushes it to OCI, pulls it back, and validates outputs.
+  params:
+    - name: tools-image
+      description: Image used to run helm_chart_oci (built earlier in pipeline)
+      type: string
+    - name: test-image
+      description: Full chart image reference with tag used by helm_chart_oci
+      type: string
+    - name: chart-version
+      description: Explicit chart version for deterministic verification
+      type: string
+      default: "1.2.3"
+  results:
+    - name: pushed-image-url
+      description: URL written by helm_chart_oci
+    - name: pushed-image-digest
+      description: Digest written by helm_chart_oci
+  workspaces:
+    - name: source
+  steps:
+    - name: run-helm-chart-oci-e2e
+      image: $(params.tools-image)
+      workingDir: $(workspaces.source.path)
+      env:
+        - name: HOME
+          value: /tekton/home
+        - name: IMAGE
+          value: $(params.test-image)
+        - name: COMMIT_SHA
+          value: e2e
+        - name: SOURCE_CODE_DIR
+          value: source
+        - name: CHART_CONTEXT
+          value: chart
+        - name: VERSION_SUFFIX
+          value: ""
+        - name: TAG_PREFIX
+          value: helm-
+        - name: IMAGE_MAPPINGS
+          value: "[]"
+        - name: CHART_VERSION
+          value: $(params.chart-version)
+        - name: APP_VERSION
+          value: e2e
+      script: |
+        #!/bin/bash
+        set -euo pipefail
+
+        mkdir -p source/chart/templates
+
+        cat > source/chart/Chart.yaml <<'EOF'
+        apiVersion: v2
+        name: placeholder
+        version: 0.1.0
+        EOF
+
+        cat > source/chart/values.yaml <<'EOF'
+        image: quay.io/example/app:latest
+        EOF
+
+        cat > source/chart/templates/configmap.yaml <<'EOF'
+        apiVersion: v1
+        kind: ConfigMap
+        metadata:
+          name: e2e
+        data:
+          key: value
+        EOF
+
+        helm_chart_oci \
+          --workdir "$(workspaces.source.path)" \
+          --result-image-url "$(results.pushed-image-url.path)" \
+          --result-image-digest "$(results.pushed-image-digest.path)" \
+          values.yaml
+
+        repo="${IMAGE%:*}"
+        chart_name="${repo##*/}"
+        expected_url="${repo}:$(params.chart-version)"
+        actual_url="$(cat "$(results.pushed-image-url.path)")"
+
+        if [ "${actual_url}" != "${expected_url}" ]; then
+          echo "Unexpected pushed image URL"
+          echo "Expected: ${expected_url}"
+          echo "Actual:   ${actual_url}"
+          exit 1
+        fi
+
+        if [ ! -s "$(results.pushed-image-digest.path)" ]; then
+          echo "Expected a non-empty pushed image digest"
+          exit 1
+        fi
+
+        pull_dest="$(workspaces.source.path)/pulled"
+        mkdir -p "${pull_dest}"
+
+        helm pull "oci://${repo%/*}/${chart_name}" \
+          --version "$(params.chart-version)" \
+          --destination "${pull_dest}"
+
+        pulled_chart="${pull_dest}/${chart_name}-$(params.chart-version).tgz"
+        if [ ! -f "${pulled_chart}" ]; then
+          echo "Expected pulled chart archive: ${pulled_chart}"
+          exit 1
+        fi
+
+        tar -tzf "${pulled_chart}" >/dev/null

--- a/helm_chart_oci/__init__.py
+++ b/helm_chart_oci/__init__.py
@@ -1,0 +1,1 @@
+"""Package and push Helm charts to OCI registries (Konflux Tekton task logic)."""

--- a/helm_chart_oci/cli.py
+++ b/helm_chart_oci/cli.py
@@ -1,0 +1,97 @@
+"""CLI entry point for Helm OCI package-and-push (Konflux Tekton)."""
+
+from __future__ import annotations
+
+import shlex
+from pathlib import Path
+
+import click
+
+from helm_chart_oci.push import chart_dir_from_parts, package_and_push
+
+
+@click.command()
+@click.option(
+    "--workdir",
+    type=click.Path(path_type=Path, exists=True, file_okay=False, dir_okay=True),
+    default=None,
+    help="Workspace root (defaults to current working directory).",
+)
+@click.option(
+    "--source-code-dir",
+    type=str,
+    envvar="SOURCE_CODE_DIR",
+    default="source",
+    show_default=True,
+)
+@click.option(
+    "--chart-context",
+    type=str,
+    envvar="CHART_CONTEXT",
+    default="dist/chart/",
+    show_default=True,
+)
+@click.option("--image", type=str, envvar="IMAGE", required=True)
+@click.option("--commit-sha", type=str, envvar="COMMIT_SHA", required=True)
+@click.option("--version-suffix", type=str, envvar="VERSION_SUFFIX", default="")
+@click.option(
+    "--tag-prefix", type=str, envvar="TAG_PREFIX", default="helm-", show_default=True
+)
+@click.option("--image-mappings", type=str, envvar="IMAGE_MAPPINGS", default="[]")
+@click.option("--chart-version", type=str, envvar="CHART_VERSION", default="")
+@click.option("--app-version", type=str, envvar="APP_VERSION", default="")
+@click.option(
+    "--result-image-url",
+    "result_image_url",
+    type=click.Path(path_type=Path),
+    required=True,
+    help="Path to write IMAGE_URL Tekton result.",
+)
+@click.option(
+    "--result-image-digest",
+    "result_image_digest",
+    type=click.Path(path_type=Path),
+    required=True,
+    help="Path to write IMAGE_DIGEST Tekton result.",
+)
+@click.argument("values_files", nargs=-1)
+def main(  # pylint: disable=too-many-arguments,too-many-positional-arguments,too-many-locals
+    workdir: Path | None,
+    source_code_dir: str,
+    chart_context: str,
+    image: str,
+    commit_sha: str,
+    version_suffix: str,
+    tag_prefix: str,
+    image_mappings: str,
+    chart_version: str,
+    app_version: str,
+    result_image_url: Path,
+    result_image_digest: Path,
+    values_files: tuple[str, ...],
+) -> None:
+    """Package a Helm chart and push it to an OCI registry."""
+    normalized_values_files: list[str] = []
+    for entry in values_files:
+        # Tekton may pass array params as one space-joined argv token (bash "$*" style).
+        normalized_values_files.extend(shlex.split(entry))
+
+    root = workdir if workdir is not None else Path.cwd()
+    chart_dir = chart_dir_from_parts(root, source_code_dir, chart_context)
+    package_and_push(
+        chart_dir=chart_dir,
+        image=image,
+        commit_sha=commit_sha,
+        version_suffix=version_suffix,
+        tag_prefix=tag_prefix,
+        image_mappings_raw=image_mappings,
+        chart_version_param=chart_version,
+        app_version_param=app_version,
+        values_files=normalized_values_files,
+        result_image_url=result_image_url,
+        result_image_digest=result_image_digest,
+    )
+
+
+if __name__ == "__main__":
+    main()  # pylint: disable=no-value-for-parameter

--- a/helm_chart_oci/pure.py
+++ b/helm_chart_oci/pure.py
@@ -1,0 +1,336 @@
+"""Pure helpers for Helm OCI package-and-push (testable without subprocess)."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from pathlib import Path
+from typing import Any
+
+import yaml  # type: ignore[import-untyped]
+
+
+def image_repository_strip_tag(image: str) -> str:
+    """
+    Match bash REPO="${IMAGE%:*}" — strip the last ':' segment (tag or digest tail).
+    """
+    if ":" not in image:
+        return image
+    return image.rsplit(":", 1)[0]
+
+
+def chart_name_from_repository(repo: str) -> str:
+    """Last path segment of a repository string (bash ${REPO##*/})."""
+    return repo.rsplit("/", 1)[-1]
+
+
+def parse_image_ref(image: str) -> tuple[str, str]:
+    """Split repository and tag; default tag 'latest' when absent."""
+    if ":" in image:
+        repo, tag = image.rsplit(":", 1)
+        return repo, tag
+    return image, "latest"
+
+
+def sort_image_mappings_longest_source_first(
+    mappings: list[dict[str, str]],
+) -> list[dict[str, str]]:
+    """Avoid partial replacements by processing longest source image strings first."""
+    return sorted(mappings, key=lambda m: len(m.get("source", "")), reverse=True)
+
+
+def load_image_mappings_json(raw: str) -> list[dict[str, str]]:
+    """Parse IMAGE_MAPPINGS JSON; treat '[]' or empty as no mappings."""
+    raw = raw.strip()
+    if not raw or raw == "[]":
+        return []
+    data: Any = json.loads(raw)
+    if not isinstance(data, list):
+        raise ValueError("IMAGE_MAPPINGS must be a JSON array")
+    out: list[dict[str, str]] = []
+    for item in data:
+        if not isinstance(item, dict):
+            raise ValueError("each IMAGE_MAPPINGS entry must be an object")
+        src = item.get("source")
+        tgt = item.get("target")
+        if not isinstance(src, str) or not isinstance(tgt, str):
+            raise ValueError("each mapping needs string 'source' and 'target'")
+        out.append({"source": src, "target": tgt})
+    return out
+
+
+def strip_git_describe_prefix(describe: str, tag_prefix: str) -> str:
+    """Remove tag_prefix from the start of a git-describe line when present."""
+    line = describe.strip()
+    if line.startswith(tag_prefix):
+        return line[len(tag_prefix) :]
+    return line
+
+
+def first_hyphen_to_dot(value: str) -> str:
+    """GNU sed '0,/-/s//./' — first '-' -> '.'."""
+    idx = value.find("-")
+    if idx < 0:
+        return value
+    return value[:idx] + "." + value[idx + 1 :]
+
+
+def first_hyphen_to_plus(value: str) -> str:
+    """GNU sed '0,/-/s//+/' — first '-' -> '+'."""
+    idx = value.find("-")
+    if idx < 0:
+        return value
+    return value[:idx] + "+" + value[idx + 1 :]
+
+
+def semver_from_git_describe_line(describe_line: str, tag_prefix: str) -> str | None:
+    """
+    Convert `git describe --tags --match=TAG_PREFIX*` line to chart semver fragment,
+    mirroring the legacy shell sed pipeline (before X.Y-only bump and fallbacks).
+    """
+    if not describe_line.strip():
+        return None
+    stripped = strip_git_describe_prefix(describe_line, tag_prefix)
+    return first_hyphen_to_plus(first_hyphen_to_dot(stripped))
+
+
+def is_xy_only_version(version: str) -> bool:
+    """True for '1.2' style (exactly one dot, no third numeric segment yet)."""
+    return bool(re.match(r"^[^.]+\.[^.]+$", version))
+
+
+def bump_xy_version_with_build_metadata(version_xy: str, short_sha: str) -> str:
+    """1.2 -> 1.2.0+sha when describe sits exactly on the tag (bash branch)."""
+    return f"{version_xy}.0+{short_sha}"
+
+
+def oci_tag_from_chart_version(chart_version: str) -> str:
+    """Helm OCI replaces '+' in semver tags with '_' (bash docker_tag)."""
+    return chart_version.replace("+", "_")
+
+
+def helm_repo_local_name_from_url(repo_url: str) -> str:
+    """
+    Legacy repo naming: host part of URL with scheme stripped, '/' removed before
+    first slash... mirrors: sed strip https/http, sed 's|/.*$||', dots -> underscores.
+    """
+    u = repo_url.strip()
+    for prefix in ("https://", "http://"):
+        if u.startswith(prefix):
+            u = u[len(prefix) :]
+            break
+    host = u.split("/", 1)[0]
+    return host.replace(".", "_")
+
+
+def substitute_template_image_line(
+    content: str, source_image: str, target_image: str
+) -> str:
+    """
+    Match legacy sed: s|image: *[\"']?SOURCE[\"']?|image: \"TARGET\"|g
+    """
+    pattern = re.compile(
+        r'image:\s*["\']?' + re.escape(source_image) + r'["\']?',
+        flags=re.MULTILINE,
+    )
+    return pattern.sub(f'image: "{target_image}"', content)
+
+
+def scoped_registry_auth_object(
+    registry: str, docker_config: dict[str, Any]
+) -> dict[str, Any]:
+    """
+    Equivalent to:
+      jq --arg registry "$REPO" '.auths[$registry]' ~/.docker/config.json |
+      jq -n --arg registry "$REPO" '{auths:{($registry):inputs}}'
+    """
+    auths = docker_config.get("auths")
+    entry: Any = None
+    if isinstance(auths, dict):
+        entry = auths.get(registry)
+    return {"auths": {registry: entry}}
+
+
+def write_scoped_docker_auth(
+    registry: str, docker_config_path: Path, dest: Path
+) -> None:
+    """Write a Docker config.json containing only auths for the given registry."""
+    raw = json.loads(docker_config_path.read_text(encoding="utf-8"))
+    scoped = scoped_registry_auth_object(registry, raw)
+    dest.write_text(json.dumps(scoped), encoding="utf-8")
+
+
+def sha256_hex_from_bytes(data: bytes) -> str:
+    """Return lowercase hex SHA-256 of the given bytes."""
+    return hashlib.sha256(data).hexdigest()
+
+
+def iter_template_yaml_files(templates_dir: Path) -> list[Path]:
+    """List .yaml/.yml files under a chart templates/ directory (recursive)."""
+    if not templates_dir.is_dir():
+        return []
+    paths: list[Path] = []
+    for p in sorted(templates_dir.rglob("*")):
+        if p.is_file() and p.suffix.lower() in (".yaml", ".yml"):
+            paths.append(p)
+    return paths
+
+
+def manifest_digest_from_skopeo_raw(raw_manifest: bytes) -> str:
+    """Digest string matching `skopeo inspect --raw | sha256sum` (sha256:...)."""
+    return f"sha256:{sha256_hex_from_bytes(raw_manifest)}"
+
+
+def _yaml_dump(document: Any) -> str:
+    """Serialize for Helm values/Chart files (stable, wide lines)."""
+    return yaml.safe_dump(
+        document,
+        default_flow_style=False,
+        sort_keys=False,
+        allow_unicode=True,
+        width=4096,
+    )
+
+
+def load_yaml_document(path: Path) -> Any:
+    """Load a YAML file; returns None for an empty file."""
+    raw = path.read_text(encoding="utf-8")
+    if not raw.strip():
+        return None
+    return yaml.safe_load(raw)
+
+
+def set_chart_name_in_chart_yaml(chart_yaml: Path, name: str) -> None:
+    """Set ``name`` in Chart.yaml (replaces prior ``yq -i '.name = strenv(chart_name)'``)."""
+    doc = load_yaml_document(chart_yaml)
+    if not isinstance(doc, dict):
+        raise ValueError(f"Chart.yaml must parse to a mapping: {chart_yaml}")
+    doc["name"] = name
+    chart_yaml.write_text(_yaml_dump(doc), encoding="utf-8")
+
+
+def chart_yaml_has_buildable_dependencies(chart_yaml: Path) -> bool:
+    """
+    Whether Chart.yaml declares non-empty dependencies (legacy ``yq -e '.dependencies'``).
+
+    Empty lists are treated as false so ``helm dependency build`` is skipped.
+    """
+    doc = load_yaml_document(chart_yaml)
+    if not isinstance(doc, dict):
+        return False
+    deps = doc.get("dependencies")
+    if deps is None:
+        return False
+    if isinstance(deps, list):
+        return len(deps) > 0
+    return bool(deps)
+
+
+def dependency_repository_scheme(repository: str) -> str:
+    """
+    Return the URL scheme for a Chart dependency ``repository`` field, lowercased.
+
+    Examples: ``https://charts.example`` → ``https``, ``oci://reg/ns/chart`` → ``oci``.
+    Returns an empty string when there is no ``://`` (legacy or relative forms).
+    """
+    s = repository.strip()
+    if "://" not in s:
+        return ""
+    return s.split("://", 1)[0].lower()
+
+
+def is_oci_dependency_repository(repository: str) -> bool:
+    """
+    True if this dependency is resolved via OCI, not a classic Helm HTTP repo.
+
+    ``helm repo add`` cannot register ``oci://`` references (see build-definitions#3439).
+    """
+    return dependency_repository_scheme(repository) == "oci"
+
+
+def chart_yaml_dependency_repository_urls(chart_yaml: Path) -> list[str]:
+    """Repository URLs from ``dependencies`` (replaces ``yq -r '.dependencies[].repository'``)."""
+    doc = load_yaml_document(chart_yaml)
+    if not isinstance(doc, dict):
+        return []
+    deps = doc.get("dependencies")
+    if not isinstance(deps, list):
+        return []
+    urls: list[str] = []
+    for dep in deps:
+        if isinstance(dep, dict):
+            repo = dep.get("repository")
+            if isinstance(repo, str) and repo.strip():
+                urls.append(repo.strip())
+    return urls
+
+
+def _mutate_values_scalar_images(
+    node: Any, source_image: str, target_image: str
+) -> None:
+    """Recurse and replace string ``image`` fields equal to ``source_image``."""
+    if isinstance(node, dict):
+        img = node.get("image")
+        if isinstance(img, str) and img == source_image:
+            node["image"] = target_image
+        for child in node.values():
+            _mutate_values_scalar_images(child, source_image, target_image)
+    elif isinstance(node, list):
+        for item in node:
+            _mutate_values_scalar_images(item, source_image, target_image)
+
+
+def _mutate_values_repo_tag_images(
+    node: Any,
+    source_repo: str,
+    source_tag: str,
+    target_repo: str,
+    target_tag: str,
+) -> None:
+    """
+    Recurse and replace ``image: {repository, tag?}`` matching source repo/tag
+    (missing tag matches ``latest``, same as legacy yq ``// "latest"``).
+    """
+    if isinstance(node, dict):
+        img = node.get("image")
+        if isinstance(img, dict):
+            repo = img.get("repository")
+            raw_tag = img.get("tag")
+            tag = "latest" if raw_tag is None else str(raw_tag)
+            if isinstance(repo, str) and repo == source_repo and tag == source_tag:
+                img["repository"] = target_repo
+                img["tag"] = target_tag
+        for child in node.values():
+            _mutate_values_repo_tag_images(
+                child, source_repo, source_tag, target_repo, target_tag
+            )
+    elif isinstance(node, list):
+        for item in node:
+            _mutate_values_repo_tag_images(
+                item, source_repo, source_tag, target_repo, target_tag
+            )
+
+
+def apply_values_file_image_mapping(  # pylint: disable=too-many-arguments,too-many-positional-arguments
+    values_file: Path,
+    source_image: str,
+    target_image: str,
+    source_repo: str,
+    source_tag: str,
+    target_repo: str,
+    target_tag: str,
+) -> None:
+    """
+    Apply IMAGE_MAPPINGS-style edits to a values YAML file using two tree passes
+    (scalar ``image`` string, then ``image.repository`` / ``image.tag``), matching
+    the previous ``yq -i 'with(.. select...)`` behavior without subprocesses.
+    """
+    data = load_yaml_document(values_file)
+    if data is None:
+        return
+    _mutate_values_scalar_images(data, source_image, target_image)
+    _mutate_values_repo_tag_images(
+        data, source_repo, source_tag, target_repo, target_tag
+    )
+    values_file.write_text(_yaml_dump(data), encoding="utf-8")

--- a/helm_chart_oci/push.py
+++ b/helm_chart_oci/push.py
@@ -1,0 +1,373 @@
+"""Orchestrate Helm package + OCI push (subprocesses to git, helm, skopeo; YAML in Python)."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from collections.abc import Callable, Mapping, Sequence
+from pathlib import Path
+from subprocess import CalledProcessError, CompletedProcess
+
+from helm_chart_oci import pure
+
+
+def _helm_plain_http_requested() -> bool:
+    """When true, append ``--plain-http`` to ``helm push`` (unencrypted HTTP registry)."""
+    return os.environ.get("HELM_CHART_OCI_PLAIN_HTTP", "").strip().lower() in (
+        "1",
+        "true",
+        "yes",
+    )
+
+
+def _tls_verify_requested() -> bool:
+    """
+    Whether to verify TLS certificates for registry traffic (Helm + skopeo).
+
+    Default is strict verification (unset or ``true``). Set
+    ``HELM_CHART_OCI_TLS_VERIFY`` to ``0`` / ``false`` / ``no`` / ``off`` to skip
+    verification (HTTPS with a self-signed or mismatched cert, or CI registries).
+    """
+    raw = os.environ.get("HELM_CHART_OCI_TLS_VERIFY")
+    if raw is None or not raw.strip():
+        return True
+    return raw.strip().lower() not in ("0", "false", "no", "off")
+
+
+def _skopeo_relax_tls() -> bool:
+    """Relax skopeo TLS checks for plain-HTTP registries or when verify is disabled."""
+    return _helm_plain_http_requested() or not _tls_verify_requested()
+
+
+def _helm_push_transport_flags() -> list[str]:
+    """Extra ``helm push`` flags for registry transport security."""
+    if _helm_plain_http_requested():
+        return ["--plain-http"]
+    if not _tls_verify_requested():
+        return ["--insecure-skip-tls-verify"]
+    return []
+
+
+def _registry_tls_cert_dir() -> Path | None:
+    """
+    Directory containing ``ca.crt`` (PEM) for registry TLS verification.
+
+    When set via ``HELM_CHART_OCI_REGISTRY_CERT_DIR``, Helm uses ``--ca-file`` and
+    skopeo uses ``--src-cert-dir`` / ``--dest-cert-dir`` / ``--cert-dir`` so
+    connections stay verified (no ``--tls-verify=false``). Do not place private
+    keys in this directory: skopeo treats ``*.key`` files as client TLS keys.
+    """
+    raw = os.environ.get("HELM_CHART_OCI_REGISTRY_CERT_DIR", "").strip()
+    if not raw:
+        return None
+    d = Path(raw)
+    if d.is_dir() and (d / "ca.crt").is_file():
+        return d
+    return None
+
+
+def _run(  # pylint: disable=too-many-arguments
+    argv: list[str],
+    *,
+    cwd: Path | None = None,
+    env: Mapping[str, str] | None = None,
+    capture_output: bool = False,
+    check: bool = True,
+    runner: Callable[..., CompletedProcess[str]] = subprocess.run,
+) -> CompletedProcess[str]:
+    return runner(
+        argv,
+        cwd=cwd,
+        env=dict(env) if env is not None else None,
+        text=True,
+        check=check,
+        capture_output=capture_output,
+    )
+
+
+def _process_image_mappings(  # pylint: disable=too-many-locals
+    chart_dir: Path,
+    mappings: list[dict[str, str]],
+    values_files: Sequence[str],
+) -> None:
+    templates = chart_dir / "templates"
+    for mapping in mappings:
+        source_image = mapping["source"]
+        target_image = mapping["target"]
+        print(
+            f"Replacing '{source_image}' with '{target_image}' in templates and values files..."
+        )
+        for template_file in pure.iter_template_yaml_files(templates):
+            text = template_file.read_text(encoding="utf-8")
+            updated = pure.substitute_template_image_line(
+                text, source_image, target_image
+            )
+            if updated != text:
+                template_file.write_text(updated, encoding="utf-8")
+
+        source_repo, source_tag = pure.parse_image_ref(source_image)
+        target_repo, target_tag = pure.parse_image_ref(target_image)
+
+        for vf_name in values_files:
+            vf = chart_dir / vf_name
+            if not vf.is_file():
+                print(f"Warning: Values file '{vf_name}' not found, skipping...")
+                continue
+            print(f"Processing {vf_name}...")
+            pure.apply_values_file_image_mapping(
+                vf,
+                source_image,
+                target_image,
+                source_repo,
+                source_tag,
+                target_repo,
+                target_tag,
+            )
+
+
+def _helm_dependency_build(
+    chart_dir: Path, runner: Callable[..., CompletedProcess[str]]
+) -> None:
+    chart_yaml = chart_dir / "Chart.yaml"
+    if not chart_yaml.is_file() or not pure.chart_yaml_has_buildable_dependencies(
+        chart_yaml
+    ):
+        return
+    print("Building Helm dependencies from Chart.lock...")
+    # OCI-only charts: skip "helm repo add" for oci:// URLs and skip "helm repo update"
+    # when no HTTP repo was added (build-definitions PR #3439).
+    non_oci_repo_added = False
+    for repo_url in sorted(set(pure.chart_yaml_dependency_repository_urls(chart_yaml))):
+        if not repo_url:
+            continue
+        if pure.is_oci_dependency_repository(repo_url):
+            print(f"Skipping helm repo add for OCI dependency: {repo_url}")
+            continue
+        non_oci_repo_added = True
+        repo_name = pure.helm_repo_local_name_from_url(repo_url)
+        print(f"Adding repository: {repo_name} ({repo_url})")
+        _run(
+            ["helm", "repo", "add", repo_name, repo_url],
+            cwd=chart_dir,
+            runner=runner,
+            check=False,
+        )
+    if non_oci_repo_added:
+        _run(["helm", "repo", "update"], cwd=chart_dir, runner=runner)
+    _run(["helm", "dependency", "build", "."], cwd=chart_dir, runner=runner)
+
+
+def _resolve_chart_version_git(
+    chart_dir: Path,
+    commit_sha: str,
+    tag_prefix: str,
+    version_suffix: str,
+    runner: Callable[..., CompletedProcess[str]],
+) -> str:
+    _run(
+        ["git", "fetch", "--unshallow", "--tags", "origin", commit_sha],
+        cwd=chart_dir,
+        runner=runner,
+    )
+    describe_proc = _run(
+        ["git", "describe", "--tags", f"--match={tag_prefix}*"],
+        cwd=chart_dir,
+        capture_output=True,
+        check=False,
+        runner=runner,
+    )
+    describe_line = (
+        "" if describe_proc.returncode != 0 else (describe_proc.stdout or "").strip()
+    )
+    chart_version = pure.semver_from_git_describe_line(describe_line, tag_prefix)
+    if chart_version is None:
+        chart_version = ""
+
+    short_sha_proc = _run(
+        ["git", "rev-parse", "--short", "HEAD"],
+        cwd=chart_dir,
+        capture_output=True,
+        runner=runner,
+    )
+    short_sha = short_sha_proc.stdout.strip()
+
+    if pure.is_xy_only_version(chart_version):
+        chart_version = pure.bump_xy_version_with_build_metadata(
+            chart_version, short_sha
+        )
+
+    if not chart_version:
+        count_proc = _run(
+            ["git", "rev-list", "HEAD", "--count"],
+            cwd=chart_dir,
+            capture_output=True,
+            runner=runner,
+        )
+        count = count_proc.stdout.strip()
+        chart_version = f"0.1.{count}+{short_sha}"
+
+    return chart_version + version_suffix
+
+
+def package_and_push(  # pylint: disable=too-many-locals,too-many-statements,too-many-arguments,too-many-branches
+    *,
+    chart_dir: Path,
+    image: str,
+    commit_sha: str,
+    version_suffix: str,
+    tag_prefix: str,
+    image_mappings_raw: str,
+    chart_version_param: str,
+    app_version_param: str,
+    values_files: Sequence[str],
+    result_image_url: Path,
+    result_image_digest: Path,
+    runner: Callable[..., CompletedProcess[str]] = subprocess.run,
+) -> None:
+    """
+    Full workflow previously implemented in build-helm-chart-oci-ta bash.
+    """
+    chart_dir = chart_dir.resolve()
+    repo = pure.image_repository_strip_tag(image)
+    chart_name = pure.chart_name_from_repository(repo)
+    pure.set_chart_name_in_chart_yaml(chart_dir / "Chart.yaml", chart_name)
+
+    mappings = pure.sort_image_mappings_longest_source_first(
+        pure.load_image_mappings_json(image_mappings_raw)
+    )
+    if mappings:
+        print("Processing image mappings...")
+        _process_image_mappings(chart_dir, mappings, values_files)
+        print("Image substitution completed.")
+
+    if chart_version_param.strip():
+        chart_version = chart_version_param.strip()
+        print(f"Using provided chart version: {chart_version}")
+    else:
+        chart_version = _resolve_chart_version_git(
+            chart_dir, commit_sha, tag_prefix, version_suffix, runner
+        )
+
+    _helm_dependency_build(chart_dir, runner)
+
+    if app_version_param.strip():
+        app_version = app_version_param.strip()
+        print(f"Using provided appVersion: {app_version}")
+    else:
+        app_version = commit_sha
+
+    tgz = f"{chart_name}-{chart_version}.tgz"
+    _run(
+        [
+            "helm",
+            "package",
+            ".",
+            "--version",
+            chart_version,
+            "--app-version",
+            app_version,
+        ],
+        cwd=chart_dir,
+        runner=runner,
+    )
+
+    docker_config = Path.home() / ".docker" / "config.json"
+    scoped = chart_dir / "scoped_authfile.json"
+    pure.write_scoped_docker_auth(repo, docker_config, scoped)
+
+    dest = f"oci://{repo.rsplit('/', 1)[0]}"
+    print("Pushing image to registry")
+    print(f"Pushing file: {tgz}")
+    print(f"Destination: {dest}")
+    push_argv: list[str] = [
+        "retry",
+        "helm",
+        "push",
+        tgz,
+        dest,
+        "--registry-config",
+        str(scoped),
+    ]
+    push_argv.extend(_helm_push_transport_flags())
+    cert_dir = _registry_tls_cert_dir()
+    if (
+        cert_dir is not None
+        and not _helm_plain_http_requested()
+        and _tls_verify_requested()
+    ):
+        push_argv.extend(["--ca-file", str(cert_dir / "ca.crt")])
+    push_proc = _run(
+        push_argv,
+        cwd=chart_dir,
+        capture_output=True,
+        check=False,
+        runner=runner,
+    )
+    output = (push_proc.stdout or "") + (push_proc.stderr or "")
+    if push_proc.returncode != 0:
+        print("Failed to push image to registry")
+        print(f"Output: {output}")
+        raise CalledProcessError(push_proc.returncode, push_proc.args, output=output)
+    print("Push command completed successfully")
+    print(f"Push output: {output}")
+
+    docker_tag = pure.oci_tag_from_chart_version(chart_version)
+    pushed = f"{repo}:{docker_tag}"
+    print(f"Constructed pushed URL: {pushed}")
+
+    print(f"Tagging chart with additional tag: {image}")
+    skopeo_copy_argv: list[str] = ["skopeo", "copy"]
+    if _skopeo_relax_tls():
+        skopeo_copy_argv.extend(["--src-tls-verify=false", "--dest-tls-verify=false"])
+    elif cert_dir is not None:
+        cdir = str(cert_dir)
+        skopeo_copy_argv.extend(["--src-cert-dir", cdir, "--dest-cert-dir", cdir])
+    skopeo_copy_argv.extend([f"docker://{pushed}", f"docker://{image}"])
+    skopeo_proc = _run(
+        skopeo_copy_argv,
+        cwd=chart_dir,
+        capture_output=True,
+        check=False,
+        runner=runner,
+    )
+    skopeo_out = (skopeo_proc.stdout or "") + (skopeo_proc.stderr or "")
+    if skopeo_proc.returncode != 0:
+        print(f"Failed to tag chart with {image}")
+        print(f"Source: docker://{pushed}")
+        print(f"Destination: docker://{image}")
+        print(f"Skopeo output: {skopeo_out}")
+        raise CalledProcessError(
+            skopeo_proc.returncode, skopeo_proc.args, output=skopeo_out
+        )
+
+    digest = ""
+    skopeo_inspect_argv: list[str] = ["skopeo", "inspect"]
+    if _skopeo_relax_tls():
+        skopeo_inspect_argv.append("--tls-verify=false")
+    elif cert_dir is not None:
+        skopeo_inspect_argv.extend(["--cert-dir", str(cert_dir)])
+    skopeo_inspect_argv.extend(["--raw", f"docker://{pushed}"])
+    inspect_proc = subprocess.run(
+        skopeo_inspect_argv,
+        cwd=chart_dir,
+        capture_output=True,
+        check=False,
+    )
+    raw_manifest = inspect_proc.stdout
+    if inspect_proc.returncode == 0 and raw_manifest:
+        digest = pure.manifest_digest_from_skopeo_raw(raw_manifest)
+        print(f"Successfully retrieved manifest digest: {digest}")
+    else:
+        print("Could not retrieve manifest digest from pushed image")
+        print("This does not affect the main functionality")
+
+    semver_url = f"{repo}:{docker_tag}"
+    result_image_url.write_text(semver_url, encoding="utf-8")
+    result_image_digest.write_text(digest, encoding="utf-8")
+
+
+def chart_dir_from_parts(
+    workdir: Path, source_code_dir: str, chart_context: str
+) -> Path:
+    """Absolute path to the chart directory under the Tekton workspace."""
+    return (workdir / source_code_dir / chart_context).resolve()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ dependencies = [
 odcs_compose_generator = "generate_compose.odcs_compose_generator:main"
 odcs_ping = "generate_compose.odcs_ping:main"
 rpm_verifier = "verify_rpms.rpm_verifier:main"
+helm_chart_oci = "helm_chart_oci.cli:main"
 clean_spacerequests = "clean_spacerequests.spacerequests_cleaner:main"
 
 [build-system]
@@ -37,5 +38,11 @@ target-version = ["py311"]
 
 [tool.pylint]
 load-plugins = ["pylint_pytest"]
+
+[tool.pytest.ini_options]
+filterwarnings = [
+    # Emitted on import from generate_compose/__init__.py; noisy for every test run.
+    "ignore:Package generate_compose is deprecated.:DeprecationWarning",
+]
 
 

--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,17 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "customManagers": [
+    {
+      "customType": "regex",
+      "description": "Zot image digest in helm-chart-oci-docker-e2e workflow (docker datasource)",
+      "fileMatch": ["^\\.github/workflows/helm-chart-oci-docker-e2e\\.yml$"],
+      "matchStrings": [
+        "ZOT_IMAGE:\\s*(?<depName>quay\\.io/konflux-ci/zot):(?<currentValue>[^@\\s]+)@(?<currentDigest>sha256:[a-f0-9]{64})"
+      ],
+      "datasourceTemplate": "docker",
+      "versioningTemplate": "docker"
+    }
+  ],
   "updateNotScheduled": false,
   "schedule": [
     "after 5pm on sunday"

--- a/tests/test_helm_chart_oci_cli.py
+++ b/tests/test_helm_chart_oci_cli.py
@@ -1,0 +1,52 @@
+"""Tests for helm_chart_oci CLI."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+from click.testing import CliRunner
+
+from helm_chart_oci import cli
+
+
+def test_cli_splits_space_joined_values_files(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Tekton can join VALUES_FILES into one argument; CLI should split like bash ``for``."""
+    captured: dict[str, Any] = {}
+
+    def fake_package_and_push(*, values_files: Any, **_kwargs: Any) -> None:
+        captured["values_files"] = list(values_files)
+
+    monkeypatch.setattr(cli, "package_and_push", fake_package_and_push)
+
+    chart = tmp_path / "source" / "dist" / "chart"
+    chart.mkdir(parents=True)
+    (chart / "Chart.yaml").write_text(
+        "apiVersion: v2\nname: x\nversion: 0.1.0\n",
+        encoding="utf-8",
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(
+        cli.main,
+        [
+            "--workdir",
+            str(tmp_path),
+            "--image",
+            "quay.io/ns/foo:tag",
+            "--commit-sha",
+            "deadbeef",
+            "--result-image-url",
+            str(tmp_path / "url"),
+            "--result-image-digest",
+            str(tmp_path / "dig"),
+            "values.yaml values-prod.yaml",
+        ],
+        catch_exceptions=False,
+    )
+
+    assert result.exit_code == 0, result.output
+    assert captured["values_files"] == ["values.yaml", "values-prod.yaml"]

--- a/tests/test_helm_chart_oci_pure.py
+++ b/tests/test_helm_chart_oci_pure.py
@@ -1,0 +1,259 @@
+"""Unit tests for helm_chart_oci.pure."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+import yaml  # type: ignore[import-untyped]
+
+from helm_chart_oci import pure
+
+# Parametrized and small unit tests: docstrings add little signal for pylint.
+# pylint: disable=missing-function-docstring
+
+
+@pytest.mark.parametrize(
+    ("image", "expected"),
+    [
+        ("quay.io/org/chart:1.2.3", "quay.io/org/chart"),
+        ("host:5000/repo/img:tag", "host:5000/repo/img"),
+        ("nexus.local/ns/app", "nexus.local/ns/app"),
+    ],
+)
+def test_image_repository_strip_tag(image: str, expected: str) -> None:
+    assert pure.image_repository_strip_tag(image) == expected
+
+
+def test_chart_name_from_repository() -> None:
+    assert pure.chart_name_from_repository("quay.io/ns/foo") == "foo"
+
+
+@pytest.mark.parametrize(
+    ("ref", "repo", "tag"),
+    [
+        ("img:1", "img", "1"),
+        ("reg.io/a/b:latest", "reg.io/a/b", "latest"),
+        ("plain", "plain", "latest"),
+    ],
+)
+def test_parse_image_ref(ref: str, repo: str, tag: str) -> None:
+    assert pure.parse_image_ref(ref) == (repo, tag)
+
+
+def test_sort_image_mappings_longest_source_first() -> None:
+    mappings = [
+        {"source": "a", "target": "t1"},
+        {"source": "ab", "target": "t2"},
+    ]
+    sorted_m = pure.sort_image_mappings_longest_source_first(mappings)
+    assert [m["source"] for m in sorted_m] == ["ab", "a"]
+
+
+def test_load_image_mappings_json_empty() -> None:
+    assert not pure.load_image_mappings_json("")
+    assert not pure.load_image_mappings_json("[]")
+    assert not pure.load_image_mappings_json("  []  ")
+
+
+def test_load_image_mappings_json_valid() -> None:
+    raw = '[{"source": "a", "target": "b"}]'
+    assert pure.load_image_mappings_json(raw) == [{"source": "a", "target": "b"}]
+
+
+def test_load_image_mappings_json_invalid_type() -> None:
+    with pytest.raises(ValueError, match="JSON array"):
+        pure.load_image_mappings_json('{"a":1}')
+
+
+def test_load_image_mappings_json_invalid_entry() -> None:
+    with pytest.raises(ValueError, match="string"):
+        pure.load_image_mappings_json('[{"source": 1, "target": "b"}]')
+
+
+@pytest.mark.parametrize(
+    ("describe", "prefix", "expected"),
+    [
+        ("helm-1.2-3-gabcdef", "helm-", "1.2.3+gabcdef"),
+        ("helm-1.2-0-gabc", "helm-", "1.2.0+gabc"),
+        ("", "helm-", None),
+        ("   ", "helm-", None),
+    ],
+)
+def test_semver_from_git_describe_line(
+    describe: str, prefix: str, expected: str | None
+) -> None:
+    assert pure.semver_from_git_describe_line(describe, prefix) == expected
+
+
+@pytest.mark.parametrize(
+    ("version", "expected"),
+    [
+        ("1.2", True),
+        ("1.2.3", False),
+        ("10.20", True),
+    ],
+)
+def test_is_xy_only_version(version: str, expected: bool) -> None:
+    assert pure.is_xy_only_version(version) is expected
+
+
+def test_bump_xy_version_with_build_metadata() -> None:
+    assert pure.bump_xy_version_with_build_metadata("1.2", "abc") == "1.2.0+abc"
+
+
+def test_oci_tag_from_chart_version() -> None:
+    assert pure.oci_tag_from_chart_version("1.0.0+git.1") == "1.0.0_git.1"
+
+
+@pytest.mark.parametrize(
+    ("url", "name"),
+    [
+        ("https://charts.example.com/stable", "charts_example_com"),
+        ("http://helm.io/foo/bar", "helm_io"),
+    ],
+)
+def test_helm_repo_local_name_from_url(url: str, name: str) -> None:
+    assert pure.helm_repo_local_name_from_url(url) == name
+
+
+def test_substitute_template_image_line() -> None:
+    src = "localhost/old"
+    tgt = "quay.io/new:1"
+    body = 'image: localhost/old\nother: x\nimage: "localhost/old"'
+    got = pure.substitute_template_image_line(body, src, tgt)
+    assert got.count(f'image: "{tgt}"') == 2
+
+
+def test_scoped_registry_auth_object() -> None:
+    cfg = {"auths": {"quay.io/ns": {"username": "u"}}}
+    scoped = pure.scoped_registry_auth_object("quay.io/ns", cfg)
+    assert scoped == {"auths": {"quay.io/ns": {"username": "u"}}}
+
+
+def test_write_scoped_docker_auth(tmp_path: Path) -> None:
+    cfg = tmp_path / "config.json"
+    cfg.write_text(
+        json.dumps({"auths": {"reg.io/foo": {"auth": "e30="}}}), encoding="utf-8"
+    )
+    dest = tmp_path / "scoped.json"
+    pure.write_scoped_docker_auth("reg.io/foo", cfg, dest)
+    data = json.loads(dest.read_text(encoding="utf-8"))
+    assert "reg.io/foo" in data["auths"]
+
+
+def test_manifest_digest_from_skopeo_raw() -> None:
+    raw = (
+        b'{"schemaVersion":2,"mediaType":"application/vnd.oci.image.manifest.v1+json"}'
+    )
+    d = pure.manifest_digest_from_skopeo_raw(raw)
+    assert d.startswith("sha256:")
+    assert len(d) == 71
+
+
+def test_iter_template_yaml_files(tmp_path: Path) -> None:
+    tpl = tmp_path / "templates"
+    (tpl / "sub").mkdir(parents=True)
+    (tpl / "a.yaml").write_text("a: 1", encoding="utf-8")
+    (tpl / "sub" / "b.yml").write_text("b: 1", encoding="utf-8")
+    (tpl / "skip.txt").write_text("", encoding="utf-8")
+    paths = {p.relative_to(tpl) for p in pure.iter_template_yaml_files(tpl)}
+    assert paths == {Path("a.yaml"), Path("sub/b.yml")}
+
+
+def test_set_chart_name_in_chart_yaml(tmp_path: Path) -> None:
+    ch = tmp_path / "Chart.yaml"
+    ch.write_text("apiVersion: v2\nname: old\nversion: 1\n", encoding="utf-8")
+    pure.set_chart_name_in_chart_yaml(ch, "newname")
+    assert "name: newname" in ch.read_text(encoding="utf-8")
+
+
+def test_chart_yaml_has_buildable_dependencies(tmp_path: Path) -> None:
+    ch = tmp_path / "Chart.yaml"
+    ch.write_text("apiVersion: v2\nname: x\n", encoding="utf-8")
+    assert pure.chart_yaml_has_buildable_dependencies(ch) is False
+    ch.write_text(
+        "apiVersion: v2\nname: x\ndependencies: []\n",
+        encoding="utf-8",
+    )
+    assert pure.chart_yaml_has_buildable_dependencies(ch) is False
+    ch.write_text(
+        "apiVersion: v2\nname: x\ndependencies:\n  - name: sub\n"
+        "    repository: https://ex.com\n    version: 1\n",
+        encoding="utf-8",
+    )
+    assert pure.chart_yaml_has_buildable_dependencies(ch) is True
+
+
+@pytest.mark.parametrize(
+    ("repo", "expected_scheme", "is_oci"),
+    [
+        ("oci://registry.example/ns/charts", "oci", True),
+        ("OCI://registry.example/ns/charts", "oci", True),
+        ("https://charts.example/stable", "https", False),
+        ("http://helm.io/charts", "http", False),
+        ("relative/path", "", False),
+    ],
+)
+def test_dependency_repository_scheme_and_oci(
+    repo: str, expected_scheme: str, is_oci: bool
+) -> None:
+    """``dependency.repository`` scheme detection (OCI vs HTTP) for Helm deps."""
+    assert pure.dependency_repository_scheme(repo) == expected_scheme
+    assert pure.is_oci_dependency_repository(repo) is is_oci
+
+
+def test_chart_yaml_dependency_repository_urls(tmp_path: Path) -> None:
+    ch = tmp_path / "Chart.yaml"
+    ch.write_text(
+        "dependencies:\n"
+        "  - {repository: https://a.com, version: '1'}\n"
+        "  - {repository: https://b.com, version: '2'}\n",
+        encoding="utf-8",
+    )
+    urls = pure.chart_yaml_dependency_repository_urls(ch)
+    assert urls == ["https://a.com", "https://b.com"]
+
+
+def test_apply_values_file_image_mapping_scalar_and_nested(tmp_path: Path) -> None:
+    vf = tmp_path / "values.yaml"
+    vf.write_text(
+        "outer:\n  image: localhost/a\npods:\n"
+        "  - name: one\n    image: localhost/a\n",
+        encoding="utf-8",
+    )
+    pure.apply_values_file_image_mapping(
+        vf,
+        "localhost/a",
+        "quay.io/b:9",
+        "localhost/a",
+        "latest",
+        "quay.io/b",
+        "9",
+    )
+    text = vf.read_text(encoding="utf-8")
+    assert text.count("quay.io/b:9") == 2
+
+
+def test_apply_values_file_image_mapping_repo_tag_and_null_tag(tmp_path: Path) -> None:
+    vf = tmp_path / "values.yaml"
+    vf.write_text(
+        "svc:\n  image:\n    repository: reg.io/img\n"
+        "other:\n  image:\n    repository: reg.io/img\n    tag: null\n",
+        encoding="utf-8",
+    )
+    pure.apply_values_file_image_mapping(
+        vf,
+        "unused",
+        "unused",
+        "reg.io/img",
+        "latest",
+        "reg.io/new",
+        "v2",
+    )
+    data = yaml.safe_load(vf.read_text(encoding="utf-8"))
+    assert data["svc"]["image"]["repository"] == "reg.io/new"
+    assert data["svc"]["image"]["tag"] == "v2"
+    assert data["other"]["image"]["repository"] == "reg.io/new"
+    assert data["other"]["image"]["tag"] == "v2"

--- a/tests/test_helm_chart_oci_push.py
+++ b/tests/test_helm_chart_oci_push.py
@@ -1,0 +1,549 @@
+"""Tests for helm_chart_oci.push orchestration."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from subprocess import CompletedProcess
+from typing import Any
+
+import pytest
+
+from helm_chart_oci.push import (
+    _helm_dependency_build,
+    _resolve_chart_version_git,
+    chart_dir_from_parts,
+    package_and_push,
+)
+
+# Nested ``fake_run`` signatures mirror ``subprocess.run``; keep checks uncluttered.
+# pylint: disable=missing-function-docstring,too-many-arguments,too-many-positional-arguments,unused-argument
+
+
+def test_chart_dir_from_parts(tmp_path: Path) -> None:
+    d = chart_dir_from_parts(tmp_path, "source", "dist/chart")
+    assert d == (tmp_path / "source" / "dist" / "chart").resolve()
+
+
+def test_resolve_chart_version_git(tmp_path: Path) -> None:
+    calls: list[list[str]] = []
+
+    def fake_run(
+        argv: list[str],
+        cwd: Path | None = None,
+        env: dict[str, str] | None = None,
+        text: bool = True,
+        check: bool = True,
+        capture_output: bool = False,
+        **_kwargs: Any,
+    ) -> CompletedProcess[str]:
+        calls.append(argv)
+        if argv[:3] == ["git", "fetch", "--unshallow"]:
+            return CompletedProcess(argv, 0, "", "")
+        if argv[:3] == ["git", "describe", "--tags"]:
+            return CompletedProcess(argv, 0, "helm-1.2-3-gabcdef\n", "")
+        if argv[:3] == ["git", "rev-parse", "--short"]:
+            return CompletedProcess(argv, 0, "abc1234\n", "")
+        if argv[:4] == ["git", "rev-list", "HEAD", "--count"]:
+            return CompletedProcess(argv, 0, "99\n", "")
+        raise AssertionError(f"unexpected argv: {argv}")
+
+    ver = _resolve_chart_version_git(
+        tmp_path, "deadbeef", "helm-", "-beta", runner=fake_run
+    )
+    assert ver == "1.2.3+gabcdef-beta"
+    assert any(c[:3] == ["git", "fetch", "--unshallow"] for c in calls)
+
+
+def test_resolve_chart_version_git_no_tag_fallback(tmp_path: Path) -> None:
+    def fake_run(
+        argv: list[str],
+        cwd: Path | None = None,
+        env: dict[str, str] | None = None,
+        text: bool = True,
+        check: bool = True,
+        capture_output: bool = False,
+        **_kwargs: Any,
+    ) -> CompletedProcess[str]:
+        if argv[:3] == ["git", "fetch", "--unshallow"]:
+            return CompletedProcess(argv, 0, "", "")
+        if argv[:3] == ["git", "describe", "--tags"]:
+            return CompletedProcess(argv, 1, "", "no tag")
+        if argv[:3] == ["git", "rev-parse", "--short"]:
+            return CompletedProcess(argv, 0, "feed\n", "")
+        if argv[:4] == ["git", "rev-list", "HEAD", "--count"]:
+            return CompletedProcess(argv, 0, "42\n", "")
+        raise AssertionError(argv)
+
+    ver = _resolve_chart_version_git(tmp_path, "sha", "helm-", "", runner=fake_run)
+    assert ver == "0.1.42+feed"
+
+
+def test_resolve_chart_version_git_xy_on_tag(tmp_path: Path) -> None:
+    def fake_run(
+        argv: list[str],
+        cwd: Path | None = None,
+        env: dict[str, str] | None = None,
+        text: bool = True,
+        check: bool = True,
+        capture_output: bool = False,
+        **_kwargs: Any,
+    ) -> CompletedProcess[str]:
+        if argv[:3] == ["git", "fetch", "--unshallow"]:
+            return CompletedProcess(argv, 0, "", "")
+        if argv[:3] == ["git", "describe", "--tags"]:
+            return CompletedProcess(argv, 0, "helm-1.2\n", "")
+        if argv[:3] == ["git", "rev-parse", "--short"]:
+            return CompletedProcess(argv, 0, "aaaabbbb\n", "")
+        if argv[:4] == ["git", "rev-list", "HEAD", "--count"]:
+            return CompletedProcess(argv, 0, "1\n", "")
+        raise AssertionError(argv)
+
+    ver = _resolve_chart_version_git(tmp_path, "sha", "helm-", "", runner=fake_run)
+    assert ver == "1.2.0+aaaabbbb"
+
+
+def test_package_and_push_writes_results(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    docker = tmp_path / ".docker"
+    docker.mkdir()
+    (docker / "config.json").write_text(
+        json.dumps({"auths": {"quay.io/ns/foo": {"auth": "e30="}}}),
+        encoding="utf-8",
+    )
+
+    chart = tmp_path / "chart"
+    chart.mkdir()
+    (chart / "Chart.yaml").write_text(
+        "apiVersion: v2\nname: foo\nversion: 0.1.0\n",
+        encoding="utf-8",
+    )
+
+    result_url = tmp_path / "IMAGE_URL"
+    result_digest = tmp_path / "IMAGE_DIGEST"
+    skopeo_copy_argv: list[str] = []
+
+    def fake_run(
+        argv: list[str],
+        cwd: Path | None = None,
+        env: dict[str, str] | None = None,
+        text: bool = True,
+        check: bool = True,
+        capture_output: bool = False,
+        **_kwargs: Any,
+    ) -> CompletedProcess[str]:
+        if argv[:2] == ["helm", "package"]:
+            assert cwd == chart
+            (chart / "foo-2.0.1.tgz").write_bytes(b"PK\x03\x04")
+            return CompletedProcess(argv, 0, "", "")
+        if argv[:2] == ["retry", "helm"]:
+            assert "--plain-http" not in argv
+            assert "--insecure-skip-tls-verify" not in argv
+            return CompletedProcess(argv, 0, "pushed", "")
+        if argv[:2] == ["skopeo", "copy"]:
+            skopeo_copy_argv.extend(argv)
+            return CompletedProcess(argv, 0, "", "")
+        raise AssertionError(f"unexpected: {argv}")
+
+    def fake_subprocess_run(
+        argv: list[str],
+        **_kwargs: Any,
+    ) -> CompletedProcess[bytes | str]:
+        if (
+            len(argv) >= 3
+            and argv[0] == "skopeo"
+            and argv[1] == "inspect"
+            and "--raw" in argv
+        ):
+            assert "--tls-verify=false" not in argv
+            return CompletedProcess(argv, 0, b'{"schemaVersion":2}', b"")
+        raise AssertionError(f"unexpected subprocess.run: {argv}")
+
+    monkeypatch.setattr("helm_chart_oci.push.subprocess.run", fake_subprocess_run)
+
+    package_and_push(
+        chart_dir=chart,
+        image="quay.io/ns/foo:custom-tag",
+        commit_sha="deadbeef",
+        version_suffix="",
+        tag_prefix="helm-",
+        image_mappings_raw="[]",
+        chart_version_param="2.0.1",
+        app_version_param="appv1",
+        values_files=(),
+        result_image_url=result_url,
+        result_image_digest=result_digest,
+        runner=fake_run,
+    )
+
+    assert result_url.read_text(encoding="utf-8") == "quay.io/ns/foo:2.0.1"
+    digest = result_digest.read_text(encoding="utf-8")
+    assert digest.startswith("sha256:")
+    assert "--src-tls-verify=false" not in skopeo_copy_argv
+
+
+def test_package_and_push_registry_cert_dir_adds_ca_for_helm_and_skopeo(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    cert_dir = tmp_path / "regcerts"
+    cert_dir.mkdir()
+    (cert_dir / "ca.crt").write_text(
+        "-----BEGIN CERTIFICATE-----\nMIIB\n", encoding="utf-8"
+    )
+    monkeypatch.setenv("HELM_CHART_OCI_REGISTRY_CERT_DIR", str(cert_dir))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    docker = tmp_path / ".docker"
+    docker.mkdir()
+    (docker / "config.json").write_text(
+        json.dumps({"auths": {"quay.io/ns/foo": {"auth": "e30="}}}),
+        encoding="utf-8",
+    )
+
+    chart = tmp_path / "chart"
+    chart.mkdir()
+    (chart / "Chart.yaml").write_text(
+        "apiVersion: v2\nname: foo\nversion: 0.1.0\n",
+        encoding="utf-8",
+    )
+
+    result_url = tmp_path / "IMAGE_URL"
+    result_digest = tmp_path / "IMAGE_DIGEST"
+    helm_push_argv: list[str] = []
+    skopeo_copy_argv: list[str] = []
+
+    def fake_run(
+        argv: list[str],
+        cwd: Path | None = None,
+        env: dict[str, str] | None = None,
+        text: bool = True,
+        check: bool = True,
+        capture_output: bool = False,
+        **_kwargs: Any,
+    ) -> CompletedProcess[str]:
+        if argv[:2] == ["helm", "package"]:
+            (chart / "foo-2.0.1.tgz").write_bytes(b"PK\x03\x04")
+            return CompletedProcess(argv, 0, "", "")
+        if argv[:2] == ["retry", "helm"]:
+            helm_push_argv.extend(argv)
+            return CompletedProcess(argv, 0, "pushed", "")
+        if argv[:2] == ["skopeo", "copy"]:
+            skopeo_copy_argv.extend(argv)
+            return CompletedProcess(argv, 0, "", "")
+        raise AssertionError(f"unexpected: {argv}")
+
+    def fake_subprocess_run(
+        argv: list[str],
+        **_kwargs: Any,
+    ) -> CompletedProcess[bytes | str]:
+        if argv[0] == "skopeo" and argv[1] == "inspect" and "--raw" in argv:
+            assert "--tls-verify=false" not in argv
+            assert "--cert-dir" in argv
+            assert str(cert_dir) in argv
+            return CompletedProcess(argv, 0, b'{"schemaVersion":2}', b"")
+        raise AssertionError(f"unexpected subprocess.run: {argv}")
+
+    monkeypatch.setattr("helm_chart_oci.push.subprocess.run", fake_subprocess_run)
+
+    package_and_push(
+        chart_dir=chart,
+        image="quay.io/ns/foo:custom-tag",
+        commit_sha="deadbeef",
+        version_suffix="",
+        tag_prefix="helm-",
+        image_mappings_raw="[]",
+        chart_version_param="2.0.1",
+        app_version_param="appv1",
+        values_files=(),
+        result_image_url=result_url,
+        result_image_digest=result_digest,
+        runner=fake_run,
+    )
+
+    assert "--ca-file" in helm_push_argv
+    assert str(cert_dir / "ca.crt") in helm_push_argv
+    assert "--insecure-skip-tls-verify" not in helm_push_argv
+    assert "--src-cert-dir" in skopeo_copy_argv
+    assert "--dest-cert-dir" in skopeo_copy_argv
+    assert str(cert_dir) in skopeo_copy_argv
+    assert "--src-tls-verify=false" not in skopeo_copy_argv
+
+
+def test_package_and_push_helm_push_plain_http_env(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("HELM_CHART_OCI_PLAIN_HTTP", "1")
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    docker = tmp_path / ".docker"
+    docker.mkdir()
+    (docker / "config.json").write_text(
+        json.dumps({"auths": {"quay.io/ns/foo": {"auth": "e30="}}}),
+        encoding="utf-8",
+    )
+
+    chart = tmp_path / "chart"
+    chart.mkdir()
+    (chart / "Chart.yaml").write_text(
+        "apiVersion: v2\nname: foo\nversion: 0.1.0\n",
+        encoding="utf-8",
+    )
+
+    result_url = tmp_path / "IMAGE_URL"
+    result_digest = tmp_path / "IMAGE_DIGEST"
+    helm_push_argv: list[str] = []
+
+    def fake_run(
+        argv: list[str],
+        cwd: Path | None = None,
+        env: dict[str, str] | None = None,
+        text: bool = True,
+        check: bool = True,
+        capture_output: bool = False,
+        **_kwargs: Any,
+    ) -> CompletedProcess[str]:
+        if argv[:2] == ["helm", "package"]:
+            (chart / "foo-2.0.1.tgz").write_bytes(b"PK\x03\x04")
+            return CompletedProcess(argv, 0, "", "")
+        if argv[:2] == ["retry", "helm"]:
+            helm_push_argv.extend(argv)
+            return CompletedProcess(argv, 0, "pushed", "")
+        if argv[:2] == ["skopeo", "copy"]:
+            assert "--src-tls-verify=false" in argv
+            return CompletedProcess(argv, 0, "", "")
+        raise AssertionError(f"unexpected: {argv}")
+
+    monkeypatch.setattr(
+        "helm_chart_oci.push.subprocess.run",
+        lambda argv, **kw: CompletedProcess(argv, 0, b"{}", b""),
+    )
+
+    package_and_push(
+        chart_dir=chart,
+        image="quay.io/ns/foo:custom-tag",
+        commit_sha="deadbeef",
+        version_suffix="",
+        tag_prefix="helm-",
+        image_mappings_raw="[]",
+        chart_version_param="2.0.1",
+        app_version_param="appv1",
+        values_files=(),
+        result_image_url=result_url,
+        result_image_digest=result_digest,
+        runner=fake_run,
+    )
+
+    assert "--plain-http" in helm_push_argv
+
+
+def test_package_and_push_tls_verify_false_uses_insecure_helm_and_skopeo(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("HELM_CHART_OCI_TLS_VERIFY", "false")
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    docker = tmp_path / ".docker"
+    docker.mkdir()
+    (docker / "config.json").write_text(
+        json.dumps({"auths": {"quay.io/ns/foo": {"auth": "e30="}}}),
+        encoding="utf-8",
+    )
+
+    chart = tmp_path / "chart"
+    chart.mkdir()
+    (chart / "Chart.yaml").write_text(
+        "apiVersion: v2\nname: foo\nversion: 0.1.0\n",
+        encoding="utf-8",
+    )
+
+    result_url = tmp_path / "IMAGE_URL"
+    result_digest = tmp_path / "IMAGE_DIGEST"
+    helm_push_argv: list[str] = []
+    skopeo_copy_argv: list[str] = []
+
+    def fake_run(
+        argv: list[str],
+        cwd: Path | None = None,
+        env: dict[str, str] | None = None,
+        text: bool = True,
+        check: bool = True,
+        capture_output: bool = False,
+        **_kwargs: Any,
+    ) -> CompletedProcess[str]:
+        if argv[:2] == ["helm", "package"]:
+            (chart / "foo-2.0.1.tgz").write_bytes(b"PK\x03\x04")
+            return CompletedProcess(argv, 0, "", "")
+        if argv[:2] == ["retry", "helm"]:
+            helm_push_argv.extend(argv)
+            return CompletedProcess(argv, 0, "pushed", "")
+        if argv[:2] == ["skopeo", "copy"]:
+            skopeo_copy_argv.extend(argv)
+            return CompletedProcess(argv, 0, "", "")
+        raise AssertionError(f"unexpected: {argv}")
+
+    def fake_subprocess_run(
+        argv: list[str],
+        **_kwargs: Any,
+    ) -> CompletedProcess[bytes | str]:
+        if argv[0] == "skopeo" and argv[1] == "inspect" and "--raw" in argv:
+            assert "--tls-verify=false" in argv
+            return CompletedProcess(argv, 0, b'{"schemaVersion":2}', b"")
+        raise AssertionError(f"unexpected subprocess.run: {argv}")
+
+    monkeypatch.setattr("helm_chart_oci.push.subprocess.run", fake_subprocess_run)
+
+    package_and_push(
+        chart_dir=chart,
+        image="quay.io/ns/foo:custom-tag",
+        commit_sha="deadbeef",
+        version_suffix="",
+        tag_prefix="helm-",
+        image_mappings_raw="[]",
+        chart_version_param="2.0.1",
+        app_version_param="appv1",
+        values_files=(),
+        result_image_url=result_url,
+        result_image_digest=result_digest,
+        runner=fake_run,
+    )
+
+    assert "--insecure-skip-tls-verify" in helm_push_argv
+    assert "--plain-http" not in helm_push_argv
+    assert "--src-tls-verify=false" in skopeo_copy_argv
+
+
+def test_package_and_push_mapping_updates_template(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    docker = tmp_path / ".docker"
+    docker.mkdir()
+    (docker / "config.json").write_text(
+        json.dumps({"auths": {"quay.io/ns/foo": {"auth": "e30="}}}),
+        encoding="utf-8",
+    )
+
+    chart = tmp_path / "chart"
+    tpl = chart / "templates"
+    tpl.mkdir(parents=True)
+    (chart / "Chart.yaml").write_text(
+        "apiVersion: v2\nname: foo\nversion: 0.1.0\n",
+        encoding="utf-8",
+    )
+    (tpl / "d.yaml").write_text("image: localhost/old\n", encoding="utf-8")
+
+    result_url = tmp_path / "IMAGE_URL"
+    result_digest = tmp_path / "IMAGE_DIGEST"
+
+    def fake_run(
+        argv: list[str],
+        cwd: Path | None = None,
+        env: dict[str, str] | None = None,
+        text: bool = True,
+        check: bool = True,
+        capture_output: bool = False,
+        **_kwargs: Any,
+    ) -> CompletedProcess[str]:
+        if argv[:2] == ["helm", "package"]:
+            (chart / "foo-2.0.0.tgz").write_bytes(b"x")
+            return CompletedProcess(argv, 0, "", "")
+        if argv[:2] == ["retry", "helm"]:
+            return CompletedProcess(argv, 0, "", "")
+        if argv[:2] == ["skopeo", "copy"]:
+            return CompletedProcess(argv, 0, "", "")
+        raise AssertionError(argv)
+
+    monkeypatch.setattr(
+        "helm_chart_oci.push.subprocess.run",
+        lambda argv, **kw: CompletedProcess(argv, 0, b"{}", b""),
+    )
+
+    raw = json.dumps([{"source": "localhost/old", "target": "quay.io/ns/foo:1"}])
+    package_and_push(
+        chart_dir=chart,
+        image="quay.io/ns/foo:tag",
+        commit_sha="cafe",
+        version_suffix="",
+        tag_prefix="helm-",
+        image_mappings_raw=raw,
+        chart_version_param="2.0.0",
+        app_version_param="",
+        values_files=("values.yaml",),
+        result_image_url=result_url,
+        result_image_digest=result_digest,
+        runner=fake_run,
+    )
+
+    assert 'image: "quay.io/ns/foo:1"' in (tpl / "d.yaml").read_text(encoding="utf-8")
+
+
+def test_helm_dependency_build_oci_only_no_repo_add_or_update(
+    tmp_path: Path,
+) -> None:
+    """PR #3439: OCI deps must not run helm repo add/update (only dependency build)."""
+    calls: list[list[str]] = []
+
+    def fake_run(
+        argv: list[str],
+        cwd: Path | None = None,
+        env: dict[str, str] | None = None,
+        text: bool = True,
+        check: bool = True,
+        capture_output: bool = False,
+        **_kwargs: Any,
+    ) -> CompletedProcess[str]:
+        calls.append(list(argv))
+        return CompletedProcess(argv, 0, "", "")
+
+    chart = tmp_path / "chart"
+    chart.mkdir()
+    (chart / "Chart.yaml").write_text(
+        "apiVersion: v2\nname: t\nversion: 1\ndependencies:\n"
+        "  - name: sub\n"
+        "    repository: oci://registry.example/ns/charts\n"
+        "    version: 1.0.0\n",
+        encoding="utf-8",
+    )
+
+    _helm_dependency_build(chart, fake_run)
+
+    assert not any(c[:3] == ["helm", "repo", "add"] for c in calls)
+    assert not any(c[:3] == ["helm", "repo", "update"] for c in calls)
+    assert ["helm", "dependency", "build", "."] in calls
+
+
+def test_helm_dependency_build_mixed_oci_and_https_runs_update(
+    tmp_path: Path,
+) -> None:
+    """PR #3439: non-OCI repos still get add + update before dependency build."""
+    calls: list[list[str]] = []
+
+    def fake_run(
+        argv: list[str],
+        cwd: Path | None = None,
+        env: dict[str, str] | None = None,
+        text: bool = True,
+        check: bool = True,
+        capture_output: bool = False,
+        **_kwargs: Any,
+    ) -> CompletedProcess[str]:
+        calls.append(list(argv))
+        return CompletedProcess(argv, 0, "", "")
+
+    chart = tmp_path / "chart"
+    chart.mkdir()
+    (chart / "Chart.yaml").write_text(
+        "apiVersion: v2\nname: t\nversion: 1\ndependencies:\n"
+        "  - name: oci_sub\n"
+        "    repository: oci://registry.example/ns/charts\n"
+        "    version: 1.0.0\n"
+        "  - name: http_sub\n"
+        "    repository: https://charts.example.com/stable\n"
+        "    version: 1.0.0\n",
+        encoding="utf-8",
+    )
+
+    _helm_dependency_build(chart, fake_run)
+
+    assert any(c[:3] == ["helm", "repo", "add"] for c in calls)
+    assert any(c[:3] == ["helm", "repo", "update"] for c in calls)
+    assert any(c[:3] == ["helm", "dependency", "build"] for c in calls)

--- a/tests/test_static_check.py
+++ b/tests/test_static_check.py
@@ -7,6 +7,7 @@ PKGS: Final[list[str]] = [
     "tests",
     "generate_compose",
     "verify_rpms",
+    "helm_chart_oci",
     "clean_spacerequests",
 ]
 


### PR DESCRIPTION
This should replace the bash-based implementation in the future, providing better maintainability and testability.

Assisted-by: Cursor