### PR TITLE
chore(KFLUXVNGD-1009): add skill for tech debt review

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,3 +37,9 @@ Repo guidance for AI/code agents working in `konflux-ci/tools`.
 - No secrets or credentials added.
 - No unrelated refactors bundled with the fix.
 - Documentation updated when introducing non-obvious behavior.
+
+## Skills
+
+| Skill | Use when |
+|-------|----------|
+| [review-hermetic-multiarch-debt](skills/review-hermetic-multiarch-debt/SKILL.md) | Reviewing PRs for Dockerfile, deps, `.tekton/`, or build/runtime debt |

--- a/skills/review-hermetic-multiarch-debt/SKILL.md
+++ b/skills/review-hermetic-multiarch-debt/SKILL.md
@@ -1,0 +1,80 @@
+---
+name: review-hermetic-multiarch-debt
+description: >-
+  Use when reviewing konflux-ci/tools pull requests that touch Dockerfile,
+  Pipfile, Pipfile.lock, pyproject.toml, .tekton/, container build scripts,
+  Python dependencies, or runtime code shipped in the tools image; or when a PR
+  adds network fetches, unpinned downloads, arch-specific binaries, or expands
+  deprecated packages (generate_compose, clean_spacerequests).
+---
+
+# Review Hermetic and Multi-Arch Debt (tools)
+
+**Goal:** Builds are **not** hermetic today and the tree has known multi-arch
+gaps. Do **not** block PRs for failing to fix that baseline. **Do** flag changes
+that **widen** hermetic or multi-arch technical debt.
+
+**Violating the letter of these checks is violating the spirit** — "not
+hermetic yet" does not justify new network-at-build-time or single-arch
+assumptions.
+
+## Triage
+
+| Signal | Result | Action |
+|--------|--------|--------|
+| Docs/tests only; no build or image impact | Out of scope | **Stop** |
+| Minimal bugfix in deprecated dir; no new deps/URLs/Dockerfile steps | Low risk | Flag only if debt signals below appear |
+| `Dockerfile`, deps, `.tekton/`, `verify_rpms/` runtime | In scope | Full pass |
+| New features/deps in `generate_compose/` or `clean_spacerequests/` | Debt | **Request changes** |
+| PR reduces debt (TARGETARCH, prefetch, remove fetch) | Positive | Approve |
+
+Konflux PR builds `linux/x86_64` + `linux/arm64`; hermetic defaults `false`.
+Baseline debt and greps: [reference.md](reference.md).
+
+## Hermetic debt — flag when the PR **adds**
+
+- Dockerfile: new `curl`/`wget`/`pip install`/`yum`/`dnf` or pipe-to-bash
+  without prefetch/Cachi2 path or maintainer exception in PR body.
+- New runtime deps in `Pipfile`/`pyproject.toml` without prefetch note.
+- **New** URL fetch at import/runtime in `verify_rpms/` (image-shipped code).
+- Tekton changes that increase live-network reliance when prefetch exists.
+- Git/private deps without a hermetic story.
+
+**Skip:** unchanged legacy Dockerfile fetches; test mocks; narrow fixes in
+deprecated dirs without new network behavior.
+
+## Multi-arch debt — flag when the PR **adds**
+
+- Dockerfile: arch-specific download without `TARGETARCH` (e.g. `*_amd64` only).
+- Runtime assuming one CPU arch without `arm64` handling where relevant.
+- Narrowing `.tekton` `build-platforms` below x86_64 + arm64 without justification.
+- Copying patterns listed in [reference.md](reference.md) into **new** lines.
+
+**Skip:** manifest test fixtures; PRs that fix existing single-arch lines.
+
+## Comment template
+
+```markdown
+**Build constraints (tools):** Increases [hermetic / multi-arch] debt:
+<concrete diff hunk>. Please avoid widening the gap. See
+`skills/review-hermetic-multiarch-debt/SKILL.md`. Suggested: <optional hint>.
+```
+
+## Rationalizations (do not accept)
+
+| Excuse | Reality |
+|--------|---------|
+| "Hermetic is off" | Default is off so builds work; new fetches still compound debt |
+| "GHA has network" | Konflux image build is the contract |
+| "Small curl" | Another prefetch gap |
+| "Multi-arch follow-up later" | Block new single-arch binaries now |
+| "Matches existing Dockerfile" | New lines copying debt still widen it |
+
+## Red flags
+
+New URL in `Dockerfile` `RUN`; new `Pipfile`/`pyproject.toml` dep;
+`yq_linux_amd64` or amd64-only binary URL; expanded deprecated package scope.
+
+## Related
+
+[AGENTS.md](../../AGENTS.md) · [reference.md](reference.md)

--- a/skills/review-hermetic-multiarch-debt/reference.md
+++ b/skills/review-hermetic-multiarch-debt/reference.md
@@ -1,0 +1,79 @@
+# Reference: hermetic and multi-arch baseline (konflux-ci/tools)
+
+## Konflux build (PR / main)
+
+| Item | Location | Notes |
+|------|----------|-------|
+| Platforms | `.tekton/tools-pull-request.yaml`, `tools-push.yaml` | `linux/x86_64`, `linux/arm64` |
+| Pipeline | `.tekton/build-pipeline.yaml` | Multi-platform `buildah` + OCI TA |
+| Hermetic param | `build-pipeline.yaml` `hermetic` | Default `'false'` (network allowed) |
+| Prefetch | `prefetch-input` | Cachi2/Hermeto JSON; empty skips prefetch |
+| Registry proxy | `enable-package-registry-proxy` | Default `'true'` for prefetch |
+
+Hermetic build = network isolation during image build plus prefetched inputs.
+Today the tools image build **relies on network** in several Dockerfile steps;
+the goal is to **not add** more of that without a plan.
+
+## Known baseline debt (do not re-copy into new lines)
+
+Documented for reviewers; fixing these is out of scope for most PRs unless the
+PR targets them.
+
+### Dockerfile (`Dockerfile`)
+
+- `curl` install script for Helm (live GitHub raw URL).
+- `wget` of `yq_linux_amd64` — **not** keyed to `TARGETARCH` (breaks or
+  mis-serves on `arm64` builds).
+- `yum install` and OpenShift client `curl` use `TARGETARCH` / `OCP_ARCH` for
+  `oc` — pattern to **follow** for new arch-specific binaries.
+
+### Python packaging
+
+- `Pipfile` / `pyproject.toml`: PyPI deps installed at image build via pipenv
+  (s2i); not vendored in-repo.
+- `pyproject.toml` entry points still expose deprecated CLIs:
+  `odcs_compose_generator`, `odcs_ping`, `clean_spacerequests`.
+
+### Deprecated directories (minimal maintenance only)
+
+| Path | Status |
+|------|--------|
+| `generate_compose/` | ODCS compose; removal planned; uses `requests.get` |
+| `clean_spacerequests/` | SpaceRequest cleanup; avoid feature expansion |
+
+AGENTS.md: do not expand these; flag new features, dependencies, or tests that
+grow scope.
+
+### Multi-arch in product logic
+
+- `verify_rpms/rpm_verifier.py` and tests model multiple architectures in image
+  manifests — new code here should remain arch-agnostic unless intentionally
+  platform-specific with tests for each supported arch.
+
+## Quick grep (PR diff)
+
+Run on changed files or the PR patch:
+
+```bash
+# Hermetic / network-at-build signals
+git diff origin/main...HEAD -- Dockerfile Pipfile pyproject.toml .tekton/ \
+  | grep -E 'curl |wget |pip install|yum install|dnf install|prefetch|hermetic'
+
+# Single-arch binary / assumption signals
+git diff origin/main...HEAD -- Dockerfile '**/*.py' \
+  | grep -E 'amd64|x86_64|arm64|aarch64|TARGETARCH|platform\.machine|uname'
+```
+
+## When a PR improves debt
+
+Approve and optionally note:
+
+- Replaces hardcoded `yq_linux_amd64` with `${TARGETARCH}` mapping.
+- Adds or updates `prefetch-input` / documents Cachi2 config for new deps.
+- Removes unused network fetch or deprecated module usage.
+- Adds tests for `arm64` behavior when introducing arch-sensitive code.
+
+## AGENTS.md line budget
+
+`AGENTS.md` is capped at 300 lines in CI. Keep long inventories in this file;
+link from AGENTS.md with one row in a Skills table.


### PR DESCRIPTION
Adding a skill that should facilitate AI agents reviews that will warn PR authors about introducing tech debt to their PRs in aspects related to hermetic builds and multiarch support.

Assisted-by: Cursor