### PR TITLE
fix: skip zstd manifests in rpm_verifier to avoid tar extraction failure

### DIFF
--- a/tests/test_rpm_verifier.py
+++ b/tests/test_rpm_verifier.py
@@ -386,6 +386,84 @@ def test_generate_image_output(
             ],
             id="Image index, return list of images from manifests",
         ),
+        pytest.param(
+            {
+                "manifests": [
+                    {
+                        "digest": "sha256:amd64gzip",
+                        "mediaType": "application/vnd.oci.image.manifest.v1+json",
+                        "platform": {"architecture": "amd64", "os": "linux"},
+                        "size": 429,
+                    },
+                    {
+                        "digest": "sha256:amd64zstd",
+                        "mediaType": "application/vnd.oci.image.manifest.v1+json",
+                        "platform": {"architecture": "amd64", "os": "linux"},
+                        "size": 429,
+                        "annotations": {
+                            "io.github.containers.compression.zstd": "true"
+                        },
+                    },
+                    {
+                        "digest": "sha256:arm64gzip",
+                        "mediaType": "application/vnd.oci.image.manifest.v1+json",
+                        "platform": {"architecture": "arm64", "os": "linux"},
+                        "size": 429,
+                    },
+                    {
+                        "digest": "sha256:arm64zstd",
+                        "mediaType": "application/vnd.oci.image.manifest.v1+json",
+                        "platform": {"architecture": "arm64", "os": "linux"},
+                        "size": 429,
+                        "annotations": {
+                            "io.github.containers.compression.zstd": "true"
+                        },
+                    },
+                ],
+                "mediaType": "application/vnd.oci.image.index.v1+json",
+                "schemaVersion": 2,
+            },
+            "quay.io/test/image:tag",
+            "sha256:1234567890",
+            [
+                "quay.io/test/image@sha256:amd64gzip",
+                "quay.io/test/image@sha256:arm64gzip",
+            ],
+            id="Dual-compression index, only gzip manifests returned",
+        ),
+        pytest.param(
+            {
+                "manifests": [
+                    {
+                        "digest": "sha256:amd64zstd",
+                        "mediaType": "application/vnd.oci.image.manifest.v1+json",
+                        "platform": {"architecture": "amd64", "os": "linux"},
+                        "size": 429,
+                        "annotations": {
+                            "io.github.containers.compression.zstd": "true"
+                        },
+                    },
+                    {
+                        "digest": "sha256:arm64zstd",
+                        "mediaType": "application/vnd.oci.image.manifest.v1+json",
+                        "platform": {"architecture": "arm64", "os": "linux"},
+                        "size": 429,
+                        "annotations": {
+                            "io.github.containers.compression.zstd": "true"
+                        },
+                    },
+                ],
+                "mediaType": "application/vnd.oci.image.index.v1+json",
+                "schemaVersion": 2,
+            },
+            "quay.io/test/image:tag",
+            "sha256:1234567890",
+            [
+                "quay.io/test/image@sha256:amd64zstd",
+                "quay.io/test/image@sha256:arm64zstd",
+            ],
+            id="Zstd-only index, all manifests returned as fallback",
+        ),
     ],
 )
 def test_get_images_from_inspection(

--- a/verify_rpms/rpm_verifier.py
+++ b/verify_rpms/rpm_verifier.py
@@ -233,7 +233,11 @@ def get_images_from_inspection(
     """
     Analyze the inspection results and return all the images for the image reference
     The image reference may refer to an image index (AKA Manifest list)
-    In this case, extract all the digests from the manifests and return the list of image references
+    In this case, extract all the digests from the manifests and return the list
+    of image references. Manifests with the io.github.containers.compression.zstd
+    annotation are skipped when non-zstd variants exist, since oc image extract
+    cannot decompress zstd layers. If all manifests are zstd, they are all
+    returned so that the error surfaces rather than silently scanning nothing.
     :param inspect_results: inspection results dictionary
     :param image_url: image url to inspect
     :param image_digest: image digest to inspect
@@ -241,9 +245,24 @@ def get_images_from_inspection(
     """
     if "manifests" in inspect_results:
         manifests = inspect_results["manifests"]
+        non_zstd_manifests = [
+            man
+            for man in manifests
+            if not man.get("annotations", {}).get(
+                "io.github.containers.compression.zstd"
+            )
+        ]
+        if non_zstd_manifests and len(non_zstd_manifests) < len(manifests):
+            print(
+                f"Skipping {len(manifests) - len(non_zstd_manifests)} "
+                "zstd-compressed manifest(s)",
+                file=sys.stderr,
+            )
+        if not non_zstd_manifests:
+            non_zstd_manifests = manifests
         image_list = [
             f"{':'.join(image_url.split(':')[:-1])}@" + man["digest"]
-            for man in manifests
+            for man in non_zstd_manifests
         ]
         return image_list
     return [f"{':'.join(image_url.split(':')[:-1])}@{image_digest}"]


### PR DESCRIPTION
oc image extract fails on zstd:chunked layers with "archive/tar: invalid tar header" because Go's archive/tar does not support zstd. Filter out manifests with the io.github.containers.compression.zstd annotation so only gzip variants are scanned. If all manifests are zstd, fall back to returning all so the error surfaces.

Ref: https://github.com/konflux-ci/architecture/blob/main/ADR/0070-dual-compression-for-container-builds.md